### PR TITLE
gcc doesn't support -flto=full

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else
 endif
 
 CFLAGS += -I$(ZSTD_PATH)/lib
-CFLAGS += -fPIC -flto=full
+CFLAGS += -fPIC -flto
 CFLAGS += -DZSTD_STATIC_LINKING_ONLY
 
 ifeq ($(shell uname),Darwin)

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "libzstd": {:git, "https://github.com/facebook/zstd.git", "09a2dbf1e83f0ac3b71c9feb13a538fd98b52baa", []},
+  "libzstd": {:git, "https://github.com/facebook/zstd.git", "334ac69db77a7b8b187939393cf4e73fdaf0baf8", []},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},


### PR DESCRIPTION
Using -flto works, and "full" is the default in clang.

Also, updated to latest zstd library (is this ok??) since the pinned
version doesn't seem valid.